### PR TITLE
Remove Windows 2019 runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,13 +18,6 @@ jobs:
       matrix:
         config:
         - {
-            name: "Windows MSVC 2019",
-            os: windows-2019,
-            cc: "cl",
-            cxx: "cl",
-            generator: "Visual Studio 16 2019"
-          }
-        - {
             name: "Windows MSVC 2022",
             os: windows-2022,
             cc: "cl",


### PR DESCRIPTION
Windows 2019 Actions runner image has been removed: https://github.com/actions/runner-images/issues/12045