### PR TITLE
Update CI 2026/05

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,6 +69,14 @@ jobs:
             generator: "Xcode",
             xcode_version: "16.4"
           }
+        - {
+            name: "macOS 26 Xcode 26.5 (ARM)",
+            os: macos-26,
+            cc: "clang",
+            cxx: "clang++",
+            generator: "Xcode",
+            xcode_version: "26.5"
+          }
         build_type: [Debug, Release]
 
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
         build_type: [Debug, Release]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Ninja (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,11 +25,11 @@ jobs:
             generator: "Visual Studio 17 2022"
           }
         - {
-            name: "Windows MSVC 2025",
-            os: windows-2025,
+            name: "Windows MSVC 2026",
+            os: windows-2025-vs2026,
             cc: "cl",
             cxx: "cl",
-            generator: "Visual Studio 17 2022"
+            generator: "Visual Studio 18 2026"
           }
         - {
             name: "Ubuntu 22 GCC 11",

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,14 +46,6 @@ jobs:
             generator: "Ninja"
           }
         - {
-            name: "macOS 13 Xcode 14",
-            os: macos-13,
-            cc: "clang",
-            cxx: "clang++",
-            generator: "Xcode",
-            xcode_version: "14.3.1"
-          }
-        - {
             name: "macOS 14 Xcode 15 (ARM)",
             os: macos-14,
             cc: "clang",


### PR DESCRIPTION
-  Remove macos 13 runner 
-  Add macos 26 runner 
-  Switch windows server 2025 to msvc 2026

In a follow-up PR we should:
- Switch from `windows-2025-vs2026` to `windows-2025`, see https://github.com/actions/runner-images/issues/14017
- Remove the `macos-14` runner, see https://github.com/actions/runner-images/issues/13518