### PR TITLE
Update CI workflow for macOS and Windows configurations

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-
 jobs:
   build:
     name: ${{ matrix.config.name }} (${{ matrix.build_type }})

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,6 @@ on:
     branches: [ "main" ]
 
 env:
-  BUILD_TYPE: Release
 
 jobs:
   build:
@@ -26,7 +25,7 @@ jobs:
           }
         - {
             name: "Windows MSVC 2026",
-            os: windows-2025-vs2026,
+            os: windows-2025,
             cc: "cl",
             cxx: "cl",
             generator: "Visual Studio 18 2026"
@@ -44,14 +43,6 @@ jobs:
             cc: "gcc",
             cxx: "g++",
             generator: "Ninja"
-          }
-        - {
-            name: "macOS 14 Xcode 15 (ARM)",
-            os: macos-14,
-            cc: "clang",
-            cxx: "clang++",
-            generator: "Xcode",
-            xcode_version: "15.4"
           }
         - {
             name: "macOS 15 Xcode 16.2 (ARM)",


### PR DESCRIPTION
Follow-up to https://github.com/biovault/FreeImage/pull/15:
- Switch from `windows-2025-vs2026` to `windows-2025`, see https://github.com/actions/runner-images/issues/14017
- Remove the `macos-14` runner, see https://github.com/actions/runner-images/issues/13518

In a follow-up PR we should:
- Add Ubuntu 26 runners and compile with gcc 15 https://github.com/actions/runner-images/issues/14226