### PR TITLE
Update macOS and Ubuntu configurations in CMake workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,6 +43,13 @@ jobs:
             generator: "Ninja"
           }
         - {
+            name: "Ubuntu 26 GCC 15",
+            os: ubuntu-26.04,
+            cc: "gcc",
+            cxx: "g++",
+            generator: "Ninja"
+          }
+        - {
             name: "macOS 15 Xcode 16.2 (ARM)",
             os: macos-15,
             cc: "clang",
@@ -59,12 +66,12 @@ jobs:
             xcode_version: "16.4"
           }
         - {
-            name: "macOS 26 Xcode 26.5 (ARM)",
+            name: "macOS 26 Xcode 26.6 (ARM)",
             os: macos-26,
             cc: "clang",
             cxx: "clang++",
             generator: "Xcode",
-            xcode_version: "26.5"
+            xcode_version: "26.6"
           }
         build_type: [Debug, Release]
 


### PR DESCRIPTION
Follow-up to https://github.com/biovault/FreeImage/pull/16:
- Add Ubuntu 26 runners and compile with gcc 15 https://github.com/actions/runner-images/issues/14226
- Update Xcode to 26.6 on MacOS 26

In a follow-up PR we should:
- Remove the Ubuntu 22 runner https://github.com/actions/runner-images/issues/14254